### PR TITLE
FIX: classification validation for undefined schemas, Custom classification

### DIFF
--- a/dicom_metadata.py
+++ b/dicom_metadata.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pandas as pd
 import pydicom
-from pydicom.datadict import DicomDictionary, tag_for_keyword
+from pydicom.datadict import DicomDictionary, tag_for_keyword, get_entry
 
 logging.basicConfig()
 log = logging.getLogger('dicom-metadata')
@@ -210,7 +210,7 @@ def fix_VM1_callback(dataset, data_element):
         pydicom.DataElement: An updated pydicom DataElement
     """
     try:
-        vr, vm, _, _, _ = DicomDictionary.get(data_element.tag)
+        vr, vm, _, _, _ = get_entry(data_element.tag)
         # Check if it is a VR string
         if vr not in ['UT', 'ST', 'LT', 'FL', 'FD', 'AT', 'OB', 'OW', 'OF', 'SL', 'SQ',
                       'SS', 'UL', 'OB/OW', 'OW/OB', 'OB or OW', 'OW or OB', 'UN'] \

--- a/manifest.json
+++ b/manifest.json
@@ -2,11 +2,11 @@
   "name": "session-export",
   "label": "GRP-9: Session Export",
   "description": "Export data (including metadata) from a given session to the specified 'export_project'. The gear will also read DICOM header information from Flywheel metadata and modify DICOM headers to reflect the changes made. Optionally, original data can be 'archived' to an <archive_project>, as configured during the gear execution. The exported, and optionally archived, session will be tagged as appropriate using the 'EXPORTED' tag. At present this gear can only be run at the session level. Output is an export log in csv format.",
-  "version": "1.3.0_rc0",
+  "version": "1.3.0_rc1",
   "custom": {
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/session-export:1.3.0_rc0"
+      "image": "flywheel/session-export:1.3.0_rc1"
     },
     "flywheel": {
       "suite": "Data Export"

--- a/manifest.json
+++ b/manifest.json
@@ -2,11 +2,11 @@
   "name": "session-export",
   "label": "GRP-9: Session Export",
   "description": "Export data (including metadata) from a given session to the specified 'export_project'. The gear will also read DICOM header information from Flywheel metadata and modify DICOM headers to reflect the changes made. Optionally, original data can be 'archived' to an <archive_project>, as configured during the gear execution. The exported, and optionally archived, session will be tagged as appropriate using the 'EXPORTED' tag. At present this gear can only be run at the session level. Output is an export log in csv format.",
-  "version": "1.2.0",
+  "version": "1.3.0_rc0",
   "custom": {
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/session-export:1.2.0"
+      "image": "flywheel/session-export:1.3.0_rc0"
     },
     "flywheel": {
       "suite": "Data Export"


### PR DESCRIPTION
The default classification is `{'Custom': []}` and an exception was thrown for modalities lacking a classification schema prior to the changes in this MR. 