### PR TITLE
Remove empty lists from file classifications before validating/updating

### DIFF
--- a/run.py
+++ b/run.py
@@ -323,6 +323,14 @@ def _modify_dicom_archive(dicom_file_path, update_keys, flywheel_dicom_header, d
     return modified_dicom_file_path
 
 
+def remove_empty_lists_from_dict(input_dict):
+    new_dict = input_dict.copy()
+    for key, value in input_dict.items():
+        if not value and isinstance(value, list):
+            new_dict.pop(key)
+    return new_dict
+
+
 def class_dict_invalid(classification):
     if not isinstance(classification, dict) or not classification:
         return True
@@ -350,6 +358,7 @@ def validate_classification(fw, f_modality, f_classification, f_name):
 
     valid_for_modality = True
     classification_schema = dict()
+    f_classification = remove_empty_lists_from_dict(f_classification)
     if class_dict_invalid(f_classification):
         return False
     if not f_modality:

--- a/run.py
+++ b/run.py
@@ -358,7 +358,8 @@ def validate_classification(fw, f_modality, f_classification, f_name):
 
     valid_for_modality = True
     classification_schema = dict()
-    f_classification = remove_empty_lists_from_dict(f_classification)
+    if isinstance(f_classification, dict):
+        f_classification = remove_empty_lists_from_dict(f_classification)
     if class_dict_invalid(f_classification):
         return False
     if not f_modality:
@@ -467,9 +468,11 @@ def _export_files(fw, acquisition, export_acquisition, session, subject, project
                 log.debug('Updating type to %s for %s' % (f.type, f.name))
                 export_acquisition.update_file(f.name, type=f.type)
             if f.classification:
-                if validate_classification(fw, f.modality, f.classification, f.name):
-                    log.debug('Updating classification to %s for %s' % (f.classification, f.name))
-                    export_acquisition.update_file_classification(f.name, f.classification)
+                classification_dict = remove_empty_lists_from_dict(f.classification)
+                if validate_classification(fw, f.modality, classification_dict, f.name):
+
+                    log.debug('Updating classification to %s for %s' % (classification_dict, f.name))
+                    export_acquisition.update_file_classification(f.name, classification_dict)
                 else:
                     log.error('Not updating classification to %s for %s' % (f.classification, f.name))
             if f.info:

--- a/tests/unit_tests/test_validate_classification.py
+++ b/tests/unit_tests/test_validate_classification.py
@@ -204,3 +204,17 @@ def test_empty_classifications():
     classification = {'Intent': [], 'Measurement': []}
     return_value = run.validate_classification(fw, None, classification, 'filename')
     assert return_value is False
+
+
+def test_classification_with_empty_and_populated_lists():
+    fw = GearContext().client
+    classification = {'Intent': ['Structural'], 'Features': ['FLAIR'], 'Custom': []}
+    return_value = run.validate_classification(fw, None, classification, 'filename')
+    assert return_value is True
+
+
+def test_remove_empty_lists_from_dict():
+    classification = {'Intent': ['Structural'], 'Features': ['FLAIR'], 'Custom': []}
+    expected_dict = {'Intent': ['Structural'], 'Features': ['FLAIR']}
+    return_value = run.remove_empty_lists_from_dict(classification)
+    assert return_value == expected_dict


### PR DESCRIPTION
Fixes a bug reported by a customer where a classification with populated and empty list values would be considered invalid.