### PR TITLE
ENH: run tests in container

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,7 @@
+ARG DOCKER_IMAGE_NAME
+
+FROM ${DOCKER_IMAGE_NAME}
+
+COPY tests ./tests
+
+RUN pip install -r tests/requirements.txt


### PR DESCRIPTION
Make `./tests/bin/docker-test.sh` build a test container and run `./tests/bin/tests.sh` inside it.  This runs the tests in the actual gear environment.

Add option "-B" to skip the build of the docker container and just run it.

Add opiton "-s" to drop into a shell inside the docker container instead of running `test.sh`.  From the shell inside the container, the tests can be run with `/src/tests/bin/tests.sh`.