### PR TITLE
fix assign_type, improve logging, test, bump manifest

### DIFF
--- a/dicom_metadata.py
+++ b/dicom_metadata.py
@@ -21,7 +21,7 @@ def assign_type(s):
     """
     Sets the type of a given input.
     """
-    if type(s) == pydicom.valuerep.PersonName or type(s) == pydicom.valuerep.PersonName3 or type(s) == pydicom.valuerep.PersonNameBase:
+    if type(s) == pydicom.valuerep.PersonName:
         return format_string(s)
     if type(s) == list or type(s) == pydicom.multival.MultiValue:
         try:
@@ -387,8 +387,9 @@ def dicom_header_extract(file_path, flywheel_header_dict):
             last = bool(idx == (len(dcm_path_list) - 1))
             tmp_dcm_data_dict = get_dcm_data_dict(dcm_path, force=True)
             if dcm_dict_is_representative(tmp_dcm_data_dict, use_rawdatastorage=last):
+                log.info('Using header dicom at %s', dcm_path)
                 dcm_header_dict = tmp_dcm_data_dict.get('header')
-            break
+                break
     else:
         dcm_header_dict = get_dcm_data_dict(dcm_path, force=True).get('header', dict())
 
@@ -441,6 +442,11 @@ def select_matching_file(file_list, flywheel_header_dict):
                 'An exception was raised when parsing %s', path, exc_info=True
             )
             continue
+    warn_str = (
+        "Could not find file that matches Flywheel header on DICOM tags: "
+        f"{str(instance_tag_list)}"
+    )
+    log.warning(warn_str)
     return None
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,11 +2,11 @@
   "name": "session-export",
   "label": "GRP-9: Session Export",
   "description": "Export data (including metadata) from a given session to the specified 'export_project'. The gear will also read DICOM header information from Flywheel metadata and modify DICOM headers to reflect the changes made. Optionally, original data can be 'archived' to an <archive_project>, as configured during the gear execution. The exported, and optionally archived, session will be tagged as appropriate using the 'EXPORTED' tag. At present this gear can only be run at the session level. Output is an export log in csv format.",
-  "version": "1.4.0_rc0",
+  "version": "1.4.0_rc1",
   "custom": {
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/session-export:1.4.0_rc0"
+      "image": "flywheel/session-export:1.4.0_rc1"
     },
     "flywheel": {
       "suite": "Data Export"

--- a/tests/unit_tests/test_assign_type.py
+++ b/tests/unit_tests/test_assign_type.py
@@ -1,0 +1,13 @@
+import pydicom
+
+from pydicom.data import get_testdata_files
+from dicom_metadata import assign_type
+
+
+def test_assign_type():
+    test_dicom_path = get_testdata_files('MR_small.dcm')[0]
+    ds = pydicom.dcmread(test_dicom_path)
+    for tag in ds.dir():
+        tag_val = ds.get(tag)
+        if type(tag_val) != str:
+            assert assign_type(tag_val) is not None


### PR DESCRIPTION
Pydicom removed PersonName3 and PersonNameBase. Tags that needed type assigned were not getting parsed due to exception.