### PR TITLE
Exclude OF VR to ensure backwards compatibility with pydicom 1.4.2

### DIFF
--- a/dicom_metadata.py
+++ b/dicom_metadata.py
@@ -173,6 +173,10 @@ def compare_dicom_headers(local_dicom_header, flywheel_dicom_header):
                 log_message += f'{key} will not be inserted into the dicom file(s)'
                 headers_match = False
                 log.warning(log_message)
+            elif vr == 'OF':
+                log_message = 'Other Float (OF) DICOM Tags are not modified by this gear\n'
+                log_message += f'{key} will not be inserted into the dicom file(s)'
+                log.warning(log_message)
             else:
                 # Check if the tags are equal
                 if local_dicom_header[key] != flywheel_dicom_header[key]:
@@ -493,7 +497,7 @@ def filter_update_keys(update_keys, dicom_path_list, force=False):
     filtered_keys = list()
     for key in update_keys:
         if DicomDictionary.get(tag_for_keyword(key)):
-            if DicomDictionary.get(tag_for_keyword(key))[0] != 'SQ':
+            if DicomDictionary.get(tag_for_keyword(key))[0] not in ['SQ', 'OF']:
                 filtered_keys.append(key)
     # If there's only one file, we already know each tag only has one unique val
     if len(dicom_path_list) > 1:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-pydicom~=1.4.2
+pydicom~=2.0.0
 pytest
 pytest-cov
 flywheel-sdk~=11.0.0

--- a/tests/unit_tests/test_filter_update_keys.py
+++ b/tests/unit_tests/test_filter_update_keys.py
@@ -11,3 +11,14 @@ def test_skip_df_logic_for_list_of_1():
 def test_return_df_if_dict_list_empty():
     result = get_dicom_df([], [])
     assert isinstance(result, pd.DataFrame)
+
+
+def test_filter_SQ_and_OF():
+    update_keys = [
+        'VectorGridData',
+        'SeriesDescription',
+        'PointCoordinatesData',
+        'HistogramSequence'
+    ]
+    result = filter_update_keys(update_keys, ['does_not_exist.dcm'])
+    assert result == ['SeriesDescription']


### PR DESCRIPTION
Exclude OF VR to ensure backwards compatibility with pydicom 1.4.2 ([pydicom 2.0.0 release notes](https://pydicom.github.io/pydicom/stable/release_notes/index.html#version-2-0-0)). 