### PR TITLE
Sanitize filename

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ git+https://github.com/pydicom/pydicom.git@9561c5d40ec96076c974b5987767dc7b78c50
 pytz~=2019.3
 tzlocal~=2.0.0
 backoff~=1.10.0
+pathvalidate~=2.3.0

--- a/run.py
+++ b/run.py
@@ -20,7 +20,7 @@ import pydicom
 
 from dicom_metadata import compare_dicom_headers, dicom_header_extract,\
     fix_type_based_on_dicom_vm, filter_update_keys
-from util import ensure_filename_safety, quote_numeric_string
+from util import get_sanitized_filename, quote_numeric_string
 
 logging.basicConfig()
 log = logging.getLogger('[GRP 9]:')
@@ -92,7 +92,7 @@ def _copy_files_from_session(fw, from_session, to_session):
         
         try:
             
-            download_file = os.path.join('/tmp', session_file.name)
+            download_file = os.path.join('/tmp', get_sanitized_filename(session_file.name))
             log.debug(f"\tdownloading file {session_file.name} to {download_file}")
             from_session.download_file(session_file.name, download_file)
             log.debug("\tcomplete")
@@ -290,11 +290,11 @@ def _export_dicom(dicom_file, tmp_dir, acquisition, session, subject, project, c
     # Download the dicom archive
 
 
-    dicom_file_path = os.path.join(tmp_dir, dicom_file.name)
+    dicom_file_path = os.path.join(tmp_dir, get_sanitized_filename(dicom_file.name))
     dicom_file.download(dicom_file_path)
     
     dicom_path_list = _retrieve_path_list(dicom_file_path)
-    
+
 
     # This is the header from Flywheel, which may have been modified
     if 'header' in dicom_file.info:
@@ -533,7 +533,7 @@ def _export_files(fw, acquisition, export_acquisition, session, subject, project
             if f.type == 'dicom':
                 upload_file_path = _export_dicom(f, temp_dir, acquisition, session, subject, project, config)
             else:
-                upload_file_path = os.path.join(temp_dir, f.name)
+                upload_file_path = os.path.join(temp_dir, get_sanitized_filename(f.name))
                 f.download(upload_file_path)
     
             # Upload the file to the export_acquisition
@@ -921,7 +921,7 @@ def main(context):
         # Generate export log
         
         file_name = '{}-{}_export_log.csv'.format(subject.code, session.label)
-        safe_file_name = ensure_filename_safety(file_name)
+        safe_file_name = get_sanitized_filename(file_name)
         
         export_log = os.path.join(context.output_dir, safe_file_name)
         log.info('Generating export log: {}'.format(export_log))

--- a/tests/unit_tests/test_filename_sanitizer.py
+++ b/tests/unit_tests/test_filename_sanitizer.py
@@ -1,26 +1,19 @@
 import pytest
 
-from util import ensure_filename_safety
+from util import get_sanitized_filename
 
 
 def test_preserve_alpha():
-    assert ensure_filename_safety('abcdefghijklmnopqrstuvwxyz') == 'abcdefghijklmnopqrstuvwxyz'
-    assert ensure_filename_safety('ABCDEFGHIJKLMNOPQRSTUVWXYZ') == 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    assert get_sanitized_filename('abcdefghijklmnopqrstuvwxyz') == 'abcdefghijklmnopqrstuvwxyz'
+    assert get_sanitized_filename('ABCDEFGHIJKLMNOPQRSTUVWXYZ') == 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
     
 def test_preserve_numeric():
-    assert ensure_filename_safety('01234567890') == '01234567890'
+    assert get_sanitized_filename('01234567890') == '01234567890'
 
 def test_preserve_special():
-    assert ensure_filename_safety('._-') == '._-'
+    assert get_sanitized_filename('._-') == '._-'
 
 def test_remove_special():
-    assert ensure_filename_safety(r"`~!@#$%^&*()=+,<>/?;:'[{]}\|") == ''
-    assert ensure_filename_safety('"') == ''
+    assert get_sanitized_filename("_a*b:c<d>e%f/(g)h+i_0.txt") == '_abcde%f(g)h+i_0.txt'
+    assert get_sanitized_filename('fi:l*e/p"a?t>h|.t<xt') == 'filepath.txt'
 
-def test_remove_space():
-    assert ensure_filename_safety('abc 123 DEF') == 'abc123DEF'
-    
-def test_remove_special_preserve_alphanumeric():
-    assert ensure_filename_safety('a_1_!_B@2-c3#.4$xyz') == 'a_1__B2-c3.4xyz'
-    assert ensure_filename_safety('&a_*1__(B2-)c3=.+4xyz?') == 'a_1__B2-c3.4xyz'
-    assert ensure_filename_safety(r"/a\_*/1\_ _/B2-\ c3=. '4xyz ]") == 'a_1__B2-c3.4xyz'

--- a/util.py
+++ b/util.py
@@ -1,6 +1,8 @@
 import logging
 import re
 
+from pathvalidate import sanitize_filename
+
 
 def quote_numeric_string(input_str):
     """
@@ -24,7 +26,7 @@ def quote_numeric_string(input_str):
     return output_str
 
 
-def ensure_filename_safety(filename):
+def get_sanitized_filename(filename):
     """A function for removing characters that are not alphanumeric, '.', '-', or '_' from an input string.
     Args:
         filename (str): an input string
@@ -37,8 +39,8 @@ def ensure_filename_safety(filename):
     except NameError:
         log = logging.getLogger(__name__)
         
-    safe_filename = re.sub(r'[^A-Za-z0-9\-\_\.]+', '', filename)
-    if filename != safe_filename:
-        log.info(f'Renaming {filename} to {safe_filename}')
+    sanitized_filename = sanitize_filename(filename)
+    if filename != sanitized_filename:
+        log.info(f'Renaming {filename} to {sanitized_filename}')
 
-    return safe_filename
+    return sanitized_filename


### PR DESCRIPTION
All files downloaded should now be downloaded with sanitized filenames. The flywheel SDK uses the basename of the file being uploaded and does not take a filename argument.